### PR TITLE
Fix incorrect results caused by uninitialized members in Object in custom parser

### DIFF
--- a/include/custom_parser.h
+++ b/include/custom_parser.h
@@ -48,6 +48,8 @@ struct Object {
   Clauses constraint;
   std::vector<Clauses> constraintAnds;
   std::vector<Clauses> constraintVals;
+
+  Object();
 };
 
 /**

--- a/src/custom_parser.cpp
+++ b/src/custom_parser.cpp
@@ -747,3 +747,14 @@ void parseCustomConstraints(std::string file,
   pegtl::file_input<> in(file);
   pegtl::parse<grammar, action, control>(in, obj);
 }
+
+/**
+ * @brief      Initialize object members
+ */
+Object::Object() {
+  isNot = false;
+  classSame = false;
+  slotSame = false;
+  classNotSame = false;
+  slotNotSame = false;
+}


### PR DESCRIPTION
In [custom_parser.cpp](https://github.com/GoodDeeds/Timetabler/blob/master/src/custom_parser.cpp), the boolean members of the Object struct were not initialized, which resulted in undefined behaviour.

This PR fixes this by defining a constructor that explicitly initializes these members.